### PR TITLE
 Slack doesn't allow spaces in emoji names

### DIFF
--- a/packs/secfootball.yaml
+++ b/packs/secfootball.yaml
@@ -8,7 +8,7 @@ emojis:
     src: http://i.imgur.com/wtUXhZi.png
   - name: missouri
     src: http://i.imgur.com/RU5ghT8.jpg
-  - name: south carolina
+  - name: south-carolina
     src: http://i.imgur.com/GRAvt1L.png
   - name: tennessee
     src: http://i.imgur.com/0cSEVqQ.gif
@@ -20,11 +20,11 @@ emojis:
     src: http://i.imgur.com/VAt7kvk.png
   - name: auburn
     src: http://i.imgur.com/LyJ5BEn.png
-  - name: louisiana state
+  - name: louisiana-state
     src: http://i.imgur.com/ddiOxAL.gif
-  - name: ole miss
+  - name: ole-miss
     src: http://i.imgur.com/ZXNDabh.png
-  - name: mississippi state
+  - name: mississippi-state
     src: http://i.imgur.com/cQWeyTZ.png
-  - name: texas am
+  - name: texas-am
     src: http://i.imgur.com/nQRHNrR.png


### PR DESCRIPTION
"Custom emoji names can only contain lower case letters, numbers, dashes and underscores"